### PR TITLE
Fix express error caused by calling res.status() twice in async handler

### DIFF
--- a/route/router/Route.js
+++ b/route/router/Route.js
@@ -132,7 +132,7 @@ Route.prototype.handlerMiddleware_ = function (req, res, next) {
   });
 
   promise.then(function (result) {
-    if (result === NO_RESULT) {
+    if (_.isUndefined(result) || result === NO_RESULT) {
       return;
     }
     if (!result && !_.isString(result)) {


### PR DESCRIPTION
If async handler returns undefined.