### PR TITLE
Add requested path to router error messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
     "express": "^4.12.0"
   },
   "scripts": {
-    "test": "node_modules/.bin/istanbul --config=.istanbul.yml cover _mocha -- --slow 10 --timeout 5000 --reporter spec --recursive ./**/*.spec.js",
-    "test-no-coverage": "mocha --slow 10 --timeout 5000 --reporter spec --recursive --bail ./**/*.spec.js",
+    "test": "node_modules/.bin/istanbul --config=.istanbul.yml cover _mocha -- --slow 10 --timeout 5000 --reporter spec --recursive './**/*.spec.js'",
+    "test-no-coverage": "mocha --slow 10 --timeout 5000 --reporter spec --recursive --bail './**/*.spec.js'",
     "coveralls": "cat ./test-coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
   }
 }

--- a/route/router/Route.js
+++ b/route/router/Route.js
@@ -94,7 +94,7 @@ Route.prototype.public = function () {
 
 /**
  * This handler sends response by itself and we shouldn't apply default response sending actions for this one.
- * 
+ *
  * Handler must return promise, which doesn't resolve until res.send is called.
  *
  * @returns {Route}
@@ -148,7 +148,8 @@ Route.prototype.handlerMiddleware_ = function (req, res, next) {
   return promise.then(function (result) {
     if (result === NO_RESULT) {
       if (!res.headersSent) {
-        throw new Error("Handler function did not return promise which won't resolve until response has been sent.");
+        throw new Error("Handler function did not return promise which won't resolve until response has been sent. " +
+          "Requested path: " + req.path);
       }
       return;
     }
@@ -158,7 +159,8 @@ Route.prototype.handlerMiddleware_ = function (req, res, next) {
       sendResult(result, req, res);
     }
     if (!res.headersSent) {
-      throw new Error("Unexpected error, response was not sent by any handler for some reason. This should not be possible.");
+      throw new Error("Unexpected error, response was not sent by any handler for some reason. " +
+          "Requested path: " + req.path);
     }
   }).catch(next);
 };
@@ -182,7 +184,7 @@ Route.prototype.handle_ = function (req, res, next) {
     if (this.defaultAuthHandler) {
       authHandlers.unshift(this.defaultAuthHandler);
     } else {
-      throw new Error("No defaultAuthHandler set for non-public route.");
+      throw new Error("No defaultAuthHandler set for non-public route. Requested path: " + req.path);
     }
   }
 
@@ -197,7 +199,7 @@ Route.prototype.handle_ = function (req, res, next) {
       } else if (ret instanceof Error) {
         throw ret;
       } else {
-        throw new Error("Invalid return value from auth handler.");
+        throw new Error("Invalid return value from auth handler. Requested path: " + req.path);
       }
     });
   });

--- a/route/router/Route.js
+++ b/route/router/Route.js
@@ -148,7 +148,7 @@ Route.prototype.handlerMiddleware_ = function (req, res, next) {
   return promise.then(function (result) {
     if (result === NO_RESULT) {
       if (!res.headersSent) {
-        throw new Error("Handler function did not return promise which won't resolve until response has been sent. " +
+        throw new Error("When using .customResponse() handler, the promise returned must not resolve before the response has been sent. " +
           "Requested path: " + req.path);
       }
       return;

--- a/route/tests/Router.spec.js
+++ b/route/tests/Router.spec.js
@@ -387,7 +387,7 @@ describe('Router', function () {
 
         var nextSpy = spy(function (err) {
           expect(err instanceof Error).to.equal(true);
-          expect(err.message).to.equal("No defaultAuthHandler set for non-public route.");
+          expect(err.message).to.contain("No defaultAuthHandler set for non-public route.");
           // Should not have called response.end or response.send or the handler.
           expect(endSpy.calls).to.have.length(0);
           expect(sendSpy.calls).to.have.length(0);

--- a/route/tests/Router.spec.js
+++ b/route/tests/Router.spec.js
@@ -574,7 +574,7 @@ describe('Router', function () {
           });
 
         var nextSpy = spy(function (err) {
-          expect(err.message).to.contain('Handler function did not return promise');
+          expect(err.message).to.contain('When using .customResponse() handler, the promise returned must not resolve before');
         });
 
         return mockExpressRouter.simulateRequest(request, response, nextSpy)


### PR DESCRIPTION
Seeing the requested path help narrow down possible causes if all other logging fails.