### PR TITLE
Add support for API versioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 language: node_js
 
 node_js:
-  - '0.12'
   - '4'
   - '5'
   - '6'

--- a/route/index.js
+++ b/route/index.js
@@ -91,7 +91,7 @@ module.exports = function (app, config) {
 
     if (!router) {
       expressRouter = express.Router();
-      router = new Router(expressRouter, config.defaultAuthHandler, config.unauthenticatedStatusCode);
+      router = new Router(expressRouter, config.defaultAuthHandler, config.unauthenticatedStatusCode, config.apiVersioning);
 
       if (!testing) {
         router = addLoggingToRouter(router, rootPath);

--- a/route/router/Route.js
+++ b/route/router/Route.js
@@ -208,12 +208,15 @@ Route.prototype.findHandler_ = function (apiVersion, fallbackToDefault, fallback
   var self = this;
   var handler;
 
+  // If no api version is provided in request
   if (_.isNil(apiVersion)) {
+    // Fallback to default handler, if configured
     if (fallbackToDefault) {
       handler = self.handlerFuncs['default'];
     }
+  // Api version is provided
   } else {
-    // Try to find handler for api version
+    // Try to find handler for the api version
     var handler = self.handlerFuncs[apiVersion];
 
     // If handler is not found, and fallbackToPrevious config is true
@@ -227,9 +230,17 @@ Route.prototype.findHandler_ = function (apiVersion, fallbackToDefault, fallback
         })
         .max() // Get the previous existing api version from the subset
         .value();
+      // Get the handler from handlerFuncs
       if (previousApiVersion !== undefined) {
         handler = self.handlerFuncs[previousApiVersion]; 
       }
+      // If no previous apiVersion handler is found, fallback to default handler if configured
+      if (handler === undefined && fallbackToDefault) {
+        handler = self.handlerFuncs['default'];
+      }
+    // At last resort, fallback to default if configured
+    } else if (!handler && fallbackToDefault) {
+      handler = self.handlerFuncs['default'];
     }
   }
   return handler;

--- a/route/router/Router.js
+++ b/route/router/Router.js
@@ -9,8 +9,9 @@ var Route = require('./Route');
  * @constructor
  * @param {express.Router} expressRouter
  * @param {function} defaultAuthHandler
+ * @param {Object} apiVersioningConfig
  */
-function Router(expressRouter, defaultAuthHandler, unauthenticatedStatusCode) {
+function Router(expressRouter, defaultAuthHandler, unauthenticatedStatusCode, apiVersioningConfig) {
   /**
    * @type {express.Router}
    */
@@ -23,6 +24,10 @@ function Router(expressRouter, defaultAuthHandler, unauthenticatedStatusCode) {
    * @type {Number}
    */
   this.unauthenticatedStatusCode = unauthenticatedStatusCode || 401;
+  /**
+   * @type {Object}
+   */
+  this.apiVersioningConfig = apiVersioningConfig
 }
 
 /**
@@ -165,7 +170,8 @@ Router.prototype._route = function (path, method) {
     method: method,
     expressRouter: this.expressRouter,
     defaultAuthHandler: this.defaultAuthHandler,
-    unauthenticatedStatusCode: this.unauthenticatedStatusCode
+    unauthenticatedStatusCode: this.unauthenticatedStatusCode,
+    apiVersioningConfig: this.apiVersioningConfig
   });
 };
 

--- a/route/tests/Router.spec.js
+++ b/route/tests/Router.spec.js
@@ -643,6 +643,318 @@ describe('Router', function () {
             expect(nextSpy.calls).to.have.length(1);
           });
       });
+
+      describe('API versioning', function() {
+        var apiVersion;
+        var routePattern;
+        var findApiVersionHandler;
+        var generateRoutePathHandler;
+        var handler;
+        var otherHandler;
+        var thirdHandler;
+        var sendData;
+        var sendOtherData;
+
+        beforeEach(function () {
+          routePattern = '/:apiVersion(v\\d+)?';
+          resolvedApiVersion = 1;
+
+          findApiVersionHandler = spy(function(req) {
+            return resolvedApiVersion;
+          });
+          generateRoutePathHandler = spy(function(path) {
+            return routePattern + path;
+          });
+
+          request.app.config = _.assign(request.app.config, {
+            apiVersioning: {
+              enabled: true,
+              availableApiVersions: [1, 2],
+              findApiVersionHandler: findApiVersionHandler,
+              generateRoutePathHandler: generateRoutePathHandler
+            }
+          });
+
+          router = new Router(mockExpressRouter, undefined, 401, request.app.config.apiVersioning);
+
+          sendData = {some: 'data'};
+          otherSendData = {other: 'otherData'};
+          thirdSendData = {other: 'thirdData'};
+
+          handler = spy(function (req, res) {
+            expect(req).to.equal(request);
+            expect(res).to.equal(response);
+            return Promise.resolve(sendData);
+          });
+          otherHandler = spy(function (req, res) {
+            expect(req).to.equal(request);
+            expect(res).to.equal(response);
+            return Promise.resolve(otherSendData);
+          });
+          thirdHandler = spy(function (req, res) {
+            expect(req).to.equal(request);
+            expect(res).to.equal(response);
+            return Promise.resolve(thirdSendData);
+          });
+        });
+
+        it('should be able to register a versioned handled', function () {
+          router[method]('/some/path')
+            .public()
+            .handler(1, handler);
+  
+          return mockExpressRouter.simulateRequest(request, response)
+            .then(function () {
+              expect(response.statusCode).to.equal(200);
+              expect(handler.calls).length(1);
+              expect(response.sentData).to.eql(JSON.stringify(sendData));
+              expect(generateRoutePathHandler.calls).length(1);
+              expect(findApiVersionHandler.calls).length(1);
+            });
+        });
+
+        it('should be able to register a versioned handled when using an auth handler', function () {
+          var auth = spy(function(req) {
+            expect(req).to.equal(request);
+            return true;
+          });
+          router[method]('/some/path')
+            .public()
+            .auth(auth)
+            .handler(1, handler);
+  
+          return mockExpressRouter.simulateRequest(request, response)
+            .then(function () {
+              expect(response.statusCode).to.equal(200);
+              expect(auth.calls).length(1);
+              expect(handler.calls).length(1);
+              expect(response.sentData).to.eql(JSON.stringify(sendData));
+              expect(generateRoutePathHandler.calls).length(1);
+              expect(findApiVersionHandler.calls).length(1);
+            });
+        });
+
+        it('should be able to register a versioned handled when using multiple auth handlers', function () {
+          var auth = spy(function(req) {
+            expect(req).to.equal(request);
+            return true;
+          });
+          var auth2 = spy(function(req) {
+            expect(req).to.equal(request);
+            return true;
+          });
+          router[method]('/some/path')
+            .public()
+            .auth(auth)
+            .auth(auth2)
+            .handler(1, handler);
+  
+          return mockExpressRouter.simulateRequest(request, response)
+            .then(function () {
+              expect(response.statusCode).to.equal(200);
+              expect(auth.calls).length(1);
+              expect(auth2.calls).length(1);
+              expect(handler.calls).length(1);
+              expect(response.sentData).to.eql(JSON.stringify(sendData));
+              expect(generateRoutePathHandler.calls).length(1);
+              expect(findApiVersionHandler.calls).length(1);
+            });
+        });
+
+        it('should be able to register a versioned handled when using middleware', function () {
+          var middlewareSpy = spy(function (req, res, next) {
+            expect(req).to.equal(request);
+            expect(res).to.equal(response);
+            setTimeout(next, 20);
+          });
+
+          router[method]('/some/path')
+            .public()
+            .middleware(middlewareSpy)
+            .handler(1, handler);
+  
+          return mockExpressRouter.simulateRequest(request, response)
+            .then(function () {
+              expect(response.statusCode).to.equal(200);
+              expect(middlewareSpy.calls).length(1);
+              expect(handler.calls).length(1);
+              expect(response.sentData).to.eql(JSON.stringify(sendData));
+              expect(generateRoutePathHandler.calls).length(1);
+              expect(findApiVersionHandler.calls).length(1);
+            });
+        });
+
+        it('should be able to register a versioned handled for two different versions', function () {
+          router[method]('/some/path')
+            .public()
+            .handler(1, handler)
+            .handler(2, otherHandler);
+
+          return mockExpressRouter.simulateRequest(request, response)
+            .then(function () {
+              expect(response.statusCode).to.equal(200);
+              expect(handler.calls).length(1);
+              expect(otherHandler.calls).length(0);
+              expect(response.sentData).to.eql(JSON.stringify(sendData));
+              expect(generateRoutePathHandler.calls).length(2);
+              expect(findApiVersionHandler.calls).length(1);
+            });
+        });
+
+        it('should register generated path correctly', function () {
+          router[method]('/some/path')
+            .public()
+            .handler(1, handler)
+          
+          expect(generateRoutePathHandler.calls).length(1);
+          expect(mockExpressRouter.path).to.equal(routePattern+'/some/path');
+        });
+
+        it('should not be able to register versioned handler two times for same API version', function () {
+          expect(function() {
+            router[method]('/some/path')
+              .public()
+              .handler(1, handler)
+              .handler(1, otherHandler);
+          }).throwError();
+        });
+
+        it('should be able to register a default handler and an other versioned handler', function () {
+          router[method]('/some/path')
+            .public()
+            .handler(1, handler)
+            .defaultHandler(2, otherHandler);
+  
+          return mockExpressRouter.simulateRequest(request, response)
+            .then(function () {
+              expect(response.statusCode).to.equal(200);
+              expect(handler.calls).length(1);
+              expect(otherHandler.calls).length(0);
+              expect(response.sentData).to.eql(JSON.stringify(sendData));
+              expect(generateRoutePathHandler.calls).length(2);
+              expect(findApiVersionHandler.calls).length(1);
+            });
+        });
+
+        it('should fallback to default handler if version not provided in request', function () {
+          resolvedApiVersion = undefined;
+
+          router[method]('/some/path')
+            .public()
+            .handler(1, handler)
+            .defaultHandler(2, otherHandler);
+  
+          return mockExpressRouter.simulateRequest(request, response)
+            .then(function () {
+              expect(response.statusCode).to.equal(200);
+              expect(handler.calls).length(0);
+              expect(otherHandler.calls).length(1);
+              expect(response.sentData).to.eql(JSON.stringify(otherSendData));
+              expect(generateRoutePathHandler.calls).length(2);
+              expect(findApiVersionHandler.calls).length(1);
+            });
+        });
+
+        it('should not fallback to default handler if fallbackToDefaultHandler config is set to false', function () {
+          router = new Router(
+            mockExpressRouter,
+            undefined,
+            401,
+            _.assign(request.app.config.apiVersioning, {
+              fallbackToDefaultHandler: false
+            })
+          );
+
+          resolvedApiVersion = undefined;
+
+          router[method]('/some/path')
+            .public()
+            .handler(1, handler)
+            .defaultHandler(2, otherHandler);
+          
+            return mockExpressRouter.simulateRequest(request, response)
+              .then(function() {
+                expect().fail('should not succeed with unkown api version');
+              })
+              .catch(function(error) {
+                expect(error.data.reason).to.equal('Api version must be defined');
+              });
+        });
+
+        it('should fallback to next api version by default if using bigger api version than defined in route handlers', function () {
+          request.app.config.apiVersioning.availableApiVersions = [1, 2, 3, 4];
+
+          router = new Router(
+            mockExpressRouter,
+            undefined,
+            401,
+            request.app.config.apiVersioning
+          );
+          resolvedApiVersion = 3;
+
+          router[method]('/some/path')
+            .public()
+            .defaultHandler(1, handler)
+            .handler(2, otherHandler)
+            .handler(4, thirdHandler);
+
+          return mockExpressRouter.simulateRequest(request, response)
+            .then(function () {
+              expect(response.statusCode).to.equal(200);
+              expect(handler.calls).length(0);
+              expect(otherHandler.calls).length(1);
+              expect(thirdHandler.calls).length(0);
+              expect(response.sentData).to.eql(JSON.stringify(otherSendData));
+              expect(generateRoutePathHandler.calls).length(3);
+              expect(findApiVersionHandler.calls).length(1);
+            });
+        });
+
+        it('should not fallback to previous api version if fallbackToPreviousApiVersion config is set to false', function () {
+          request.app.config.apiVersioning.availableApiVersions = [1,2,3];
+
+          router = new Router(
+            mockExpressRouter,
+            undefined,
+            401,
+            _.assign(request.app.config.apiVersioning, {
+              fallbackToPreviousApiVersion: false
+            })
+          );
+          resolvedApiVersion = 3;
+
+          router[method]('/some/path')
+            .public()
+            .defaultHandler(1, handler)
+            .handler(2, otherHandler);
+  
+          return mockExpressRouter.simulateRequest(request, response)
+            .then(function() {
+              expect().fail('should not succeed because handler is not defined for this api version');
+            })
+            .catch(function(error) {
+              expect(error.data.reason).to.equal('Handler not found');
+            });
+        });
+
+        it('status code should be 404 if trying to use unknown api version', function () {
+          resolvedApiVersion = 3;
+
+          router[method]('/some/path')
+            .public()
+            .handler(1, handler)
+          
+            return mockExpressRouter.simulateRequest(request, response)
+              .then(function() {
+                expect().fail('should not succeed with unkown api version');
+              })
+              .catch(function(error) {
+                expect(error.data.reason).to.equal('specified apiVersion not available. Available api versions are: 1, 2');
+              });
+        });
+
+      });
+
     });
   });
 


### PR DESCRIPTION
- Refactor Route to support multiple handlers and api versioning.
- Add HeaderApiVersioning and RouteApiVersioning features.
- Refactor Router to forward apiVersioningConfig from Router's config to Route.
- Also resolve feature name in Router to the actual versioning feature.
- Add tests for Router and both versioning features.